### PR TITLE
Use paste0() over paste(sep="")

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 p <- function(...) {
-  regex(paste(sep = "", collapse = "", ...))
+  regex(paste0(collapse = "", ...))
 }
 
 `%==%` <- function(x, y) {


### PR DESCRIPTION
The output is equivalent but `paste0()` is more efficient/concise/canonical (unless you're trying to retain an _ancient_ R version dependency)