### PR TITLE
Preserve state of random number generator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,5 @@ Collate:
     'wildcards.R'
     'zzz.R'
 Config/Needs/website: r-lib/pkgdown, tidyverse/tidytemplate
+Imports: 
+    withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## Rex (development version)
 
+* Rex no longer changes the state of the random number generator when attached.
+
 ## Rex Version 1.2.1 ##
 
 * Kevin Ushey is now the maintainer

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,8 @@
 .onAttach <- function(lib, pkg) { # nolint
+  withr::with_preserve_seed({
   if (!interactive() || stats::runif(1) > 0.1) return()
 
   packageStartupMessage("Welcome to rex, the friendly regular expression helper!\n",
                         "Use 'rex_mode()' to toggle code completion for rex shortcuts and functions.")
+  })
 }


### PR DESCRIPTION
Per #91 this PR preserves the seed of the random number generator on package attachment.

This does add {withr} as a hard dependency. Whilst I think we could avoid this (maybe setting .Random.seed back on.exit is sufficient), {withr} is lightweight and well tested so I erred towards using it rather than missing something subtle.